### PR TITLE
feat(api): add leaderboard endpoint

### DIFF
--- a/packages/gateway/src/controllers/Leaderboard.ts
+++ b/packages/gateway/src/controllers/Leaderboard.ts
@@ -1,0 +1,19 @@
+import * as LeaderboardService from "../services/Leaderboard";
+
+import { response } from "./index";
+import { logger } from "@1kv/common";
+import { gatewayLabel } from "../constants";
+import { requestEmitter } from "../events/requestEmitter";
+
+export default class LeaderboardController {
+  public static async getCandidatesWithRewards(context: any): Promise<void> {
+    requestEmitter.emit("requestReceived");
+    if (await context.cashed()) {
+      logger.info(`{Gateway} getCandidate is cached`, gatewayLabel);
+      return;
+    }
+
+    response(context, 200, await LeaderboardService.getCandidatesWithRewards());
+  }
+
+}

--- a/packages/gateway/src/routes/index.ts
+++ b/packages/gateway/src/routes/index.ts
@@ -9,6 +9,7 @@ import Location from "../controllers/Location";
 import Validator from "../controllers/Validators";
 import Rewards from "../controllers/Rewards";
 import Block from "../controllers/Block";
+import Leaderboard from "../controllers/Leaderboard";
 import { response } from "../controllers";
 import { queries } from "@1kv/common";
 
@@ -67,6 +68,7 @@ const API = {
   BlockIndex: "/blockindex",
   StatsTotalReqeusts: "/stats/totalRequests",
   StatsEndpointCounts: "/stats/endpointCounts",
+  Leaderboard: "/leaderboard"
 };
 
 router.get(API.Candidate, Candidate.getCandidate);
@@ -132,5 +134,7 @@ router.get(API.StatsEndpointCounts, Stats.getEndpointCounts);
 router.get(API.Release, async (ctx: any) => {
   response(ctx, 200, await queries.getLatestRelease());
 });
+
+router.get(API.Leaderboard, Leaderboard.getCandidatesWithRewards)
 
 export default router;

--- a/packages/gateway/src/services/Leaderboard.ts
+++ b/packages/gateway/src/services/Leaderboard.ts
@@ -1,0 +1,74 @@
+import { logger, queries } from "@1kv/common";
+
+const label = { label: "Gateway" };
+
+export const getCandidateData = async (candidate: any): Promise<any> => {
+  const [metadata, score, nominations, location, rewards] = await Promise.all([
+    queries.getChainMetadata(),
+    queries.getLatestValidatorScore(candidate.stash),
+    queries.getLatestNominatorStake(candidate.stash),
+    queries.getCandidateLocation(candidate.slotId),
+    queries.getTotalValidatorRewards(candidate.stash)
+  ]);
+
+  const denom = Math.pow(10, metadata.decimals);
+
+  return {
+    slotId: candidate.slotId,
+    kyc: candidate.kyc,
+    discoveredAt: candidate.discoveredAt,
+    nominatedAt: candidate.nominatedAt,
+    offlineSince: candidate.offlineSince,
+    offlineAccumulated: candidate.offlineAccumulated,
+    rank: candidate.rank || 0,
+    faults: candidate.faults,
+    invalidityReasons: candidate.invalidityReasons,
+    unclaimedEras: candidate.unclaimedEras,
+    inclusion: candidate.inclusion,
+    name: candidate.name,
+    stash: candidate.stash,
+    kusamaStash: candidate.kusamaStash,
+    commission: candidate.commission,
+    identity: candidate.identity,
+    active: candidate.active,
+    bonded: candidate.bonded / denom,
+    valid: candidate.valid,
+    validity: candidate.invalidity,
+    score: score,
+    total: score && score.total ? score.total : 0,
+    location: location?.city,
+    provider: location?.provider,
+    cpu: location?.cpu,
+    memory: location?.memory,
+    coreCount: location?.coreCount,
+    vm: location?.vm,
+    region: location?.region,
+    country: location?.country,
+    matrix: candidate.matrix,
+    version: candidate.version,
+    implementation: candidate.implementation,
+    queuedKeys: candidate.queuedKeys,
+    nextKeys: candidate.nextKeys,
+    rewardDestination: candidate.rewardDestination,
+    nominations: {
+      totalStake: nominations?.totalStake,
+      inactiveStake: nominations?.inactiveStake,
+      activeNominators: nominations?.activeNominators?.length,
+      inactiveNominators: nominations?.inactiveNominators?.length,
+    },
+    rewards: rewards,
+  };
+};
+
+export const getCandidatesWithRewards = async (): Promise<any> => {
+  const allCandidates = await queries.allCandidates();
+  const candidatesWithAdditionalFields = await Promise.all(
+    allCandidates.map(async (candidate) => {
+      return await getCandidateData(candidate);
+    }),
+  );
+  
+  return candidatesWithAdditionalFields.sort((a, b) => {
+    return b.total - a.total;
+  });
+};

--- a/packages/gateway/src/swagger.yml
+++ b/packages/gateway/src/swagger.yml
@@ -21,9 +21,19 @@ tags:
     description: Querying location data
   - name: Score
     description: Querying score data
+  - name: Leaderboard
+    description: Querying validator leaderboard
 
 paths:
 
+  /leaderboard:
+    get:
+      tags:
+        - Leaderboard
+      summary: Retrieve a list of candidates with their rewards
+      responses:
+        200:
+          description: Successful response with a list of candidates
 
   /candidate/{candidateStash}:
     get:


### PR DESCRIPTION
Added endpoint for fetching leaderboard, basically candidates with their total rewards. Later on we can extend to have more information